### PR TITLE
AND-14216: Upgrade WebRTC build to milestone 145 with Android 16 support

### DIFF
--- a/.github/workflows/build_webrtc.yml
+++ b/.github/workflows/build_webrtc.yml
@@ -9,15 +9,10 @@ on:
       milestone:
         description: The milestone number of the WebRTC branch
         required: true
-      unstripped:
-        description: 'Build webrtc with symbols unstripped?'
-        type: boolean
-        required: true
-        default: false
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Allocate space for build
       run: |
@@ -26,7 +21,7 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@v4.1.1
-    
+
     - name: Install Python and binutils
       run: |
         sudo apt-get update
@@ -36,41 +31,65 @@ jobs:
     - name: Fetch depot tools
       run: |
         git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-      
+
     - name: Add depot tools to path
       run: |
         echo "$(pwd)/depot_tools" >> $GITHUB_PATH
 
     - name: Fetch WebRTC revision
       run: |
-        python3 build.py fetch --revision branch-heads/${{  inputs.branch_number }}
+        python3 build.py fetch --revision branch-heads/${{ inputs.branch_number }}
 
-    - name: Build WebRTC
+    - name: Build stripped WebRTC
       run: |
-        python3 build.py build ${{ (inputs.unstripped && '--unstripped') || '' }}
+        python3 build.py build
 
-    - name: Get and rename built files
+    - name: Save stripped AAR and build unstripped
       run: |
-        mv ./src/libwebrtc.aar libwebrtc-${{ inputs.milestone }}.aar
+        cp ./src/libwebrtc.aar libwebrtc-${{ inputs.milestone }}.aar
+        python3 build.py build --unstripped
+
+    - name: Save unstripped AAR and license
+      run: |
+        mv ./src/libwebrtc.aar libwebrtc-${{ inputs.milestone }}-unstripped.aar
         mv ./src/LICENSE.md LICENSE.md
 
+    - name: Upload build artifacts
+      if: github.ref != 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: webrtc-aars
+        path: |
+          libwebrtc-${{ inputs.milestone }}.aar
+          libwebrtc-${{ inputs.milestone }}-unstripped.aar
+          LICENSE.md
+
     - name: Create Release
+      if: github.ref == 'refs/heads/main'
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ inputs.milestone }}${{ inputs.unstripped && '-unstripped' || ''}} # add '-unstripped' suffix if needed
-        release_name: v${{ inputs.milestone }}${{ inputs.unstripped && '-unstripped' || ''}}
+        tag_name: v${{ inputs.milestone }}
+        release_name: v${{ inputs.milestone }}
         body: |
-          Built off of the ${{inputs.milestone}} branch here: https://chromiumdash.appspot.com/branches 
+          Built off of the ${{ inputs.milestone }} branch here: https://chromiumdash.appspot.com/branches
 
+          Includes both stripped (for app distribution) and unstripped (for Crashlytics symbol upload) AARs.
 
-          ## 📃 License
+          ## Crashlytics Native Symbol Upload
+          To upload native debug symbols for crash reporting:
+          ```bash
+          unzip libwebrtc-${{ inputs.milestone }}-unstripped.aar "jni/*" -d unstripped-symbols
+          firebase crashlytics:symbols:upload --app=<FIREBASE_APP_ID> unstripped-symbols/jni
+          ```
+
+          ## License
           * WebRTC License: https://webrtc.org/support/license
 
-    - name: Upload release aar
-      id: upload-release-aar
+    - name: Upload stripped AAR
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,9 +98,20 @@ jobs:
         asset_path: ./libwebrtc-${{ inputs.milestone }}.aar
         asset_name: libwebrtc-${{ inputs.milestone }}.aar
         asset_content_type: application/zip
-    
-    - name: Upload release license
-      id: upload-release-license
+
+    - name: Upload unstripped AAR
+      if: github.ref == 'refs/heads/main'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./libwebrtc-${{ inputs.milestone }}-unstripped.aar
+        asset_name: libwebrtc-${{ inputs.milestone }}-unstripped.aar
+        asset_content_type: application/zip
+
+    - name: Upload license
+      if: github.ref == 'refs/heads/main'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -122,7 +122,23 @@ Still inside the container's bash shell, run the following command to build the 
 python3 build.py build
 ```
 
-Again, the full output will be written to a log file. The .aar file will be placed at the `/webrtc-android/src/libwebrtc.aar` path. To extract it and the license file from the docker container, run the following commands:
+Again, the full output will be written to a log file. The .aar file will be placed at the `/webrtc-android/src/libwebrtc.aar` path.
+
+The build script automatically checks 16KB page alignment for 64-bit .so files (arm64-v8a, x86_64). This is required for Android 16 compatibility.
+
+#### Building an unstripped AAR (for Crashlytics)
+
+To generate an AAR with debug symbols intact (needed for native crash symbolication in Firebase Crashlytics):
+
+```bash
+python3 build.py build --unstripped
+```
+
+This produces a larger AAR containing unstripped `.so` files with full symbol information. This AAR is not shipped in the app — it's only used to upload debug symbols to Crashlytics.
+
+#### Extracting files from Docker
+
+To extract the built files from the docker container, run the following commands:
 
 ```bash
 docker cp webrtc-android:/webrtc-android/src/libwebrtc.aar .
@@ -130,6 +146,21 @@ docker cp webrtc-android:/webrtc-android/src/LICENSE.md .
 ```
 
 They will be saved in the directory where you are running the command. Then you can simply create a release in https://github.com/ecobee/webrtc-android and upload these files as artifacts. The release tag should be `v<milestone>.0.0`, and the .aar file should be renamed to `libwebrtc-<milestone>.0.0.aar`, e.g. for milestone 119 the tag will be `v119.0.0` and the file name will be `libwebrtc-119.0.0.aar`. It's important to match these naming conventions so the ecobee android app build can fetch the library.
+
+### Uploading Crashlytics native symbols
+
+When upgrading the WebRTC version in the ecobee app, upload the unstripped symbols to Firebase Crashlytics so native crashes are symbolicated with function names and source references.
+
+1. Download or build the unstripped AAR (e.g. `libwebrtc-145-unstripped.aar`)
+2. Extract the `.so` files:
+   ```bash
+   unzip libwebrtc-145-unstripped.aar "jni/*" -d unstripped-symbols
+   ```
+3. Upload to Crashlytics using the Firebase CLI:
+   ```bash
+   firebase crashlytics:symbols:upload --app=<FIREBASE_APP_ID> unstripped-symbols/jni
+   ```
+   Replace `<FIREBASE_APP_ID>` with your Android app's Firebase App ID (found in Firebase console under Project Settings).
 
 ### Clean up
 
@@ -144,7 +175,16 @@ docker image prune
 
 ## Building with the Github Action
 
-The Github Action takes two inputs, the milestone number, and the branch number of the WebRTC revision to be build. For example, for milestone 119, the inputs would be 6045 for the branch number, and 119.0.0 for the milestone number.
+The Github Action takes two inputs:
+- **branch_number**: The branch number from https://chromiumdash.appspot.com/branches (e.g. `7632`)
+- **milestone**: The milestone number (e.g. `145`)
+
+The workflow automatically builds **both** a stripped AAR (for the app) and an unstripped AAR (for Crashlytics symbol upload), then uploads both to the GitHub release along with the license file.
+
+For example, for milestone 145 (branch-heads/7632), the workflow will produce:
+- `libwebrtc-145.aar` — stripped, for app distribution
+- `libwebrtc-145-unstripped.aar` — unstripped, for Crashlytics symbol upload
+- `LICENSE.md`
 
 For local testing, [act](https://github.com/nektos/act) can be used. First, follow the instructions in the act repository to install act and Docker as needed. To run the steps for creating and uploading files for a release locally, you will need to provide a GITHUB_TOKEN. See the instructions to do so [here](https://github.com/nektos/act?tab=readme-ov-file#github_token). If you'd like to obtain the files locally, follow the instructions below without providing a token.
 
@@ -153,8 +193,8 @@ Once you have installed act and have checked out this repository, create a json 
 {
     "action": "workflow_dispatch",
     "inputs": {
-        "branch_number": "6045",
-        "milestone": "119.0.0"
+        "branch_number": "7632",
+        "milestone": "145"
     }
 }
 ```
@@ -168,6 +208,7 @@ Act will create a docker container for this workflow and another will be created
 
 ```bash
 docker cp {act container id}:$(pwd)/libwebrtc-{milestone number}.aar .
+docker cp {act container id}:$(pwd)/libwebrtc-{milestone number}-unstripped.aar .
 docker cp {act container id}:$(pwd)/LICENSE.md .
 ```
 

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+import zipfile
 
 def log(message, logfile):
     print(message)
@@ -17,15 +18,17 @@ def create_logfile(path=None):
     log(f"Writing to log file '{logfile.name}'", logfile)
     return logfile
 
-def run_command(args, logfile, cwd=None):
+def run_command(args, logfile, cwd=None, stdin_input=None):
     log(f"Running '{' '.join(args)}' in '{cwd if cwd is not None else os.getcwd()}'", logfile)
     logfile.flush()
     try:
-        subprocess.run(args, cwd=cwd, check=True, stderr=subprocess.STDOUT, stdout=logfile)
+        subprocess.run(args, cwd=cwd, check=True, stderr=subprocess.STDOUT, stdout=logfile,
+                       input=stdin_input)
     except:
         log('Command failed.', logfile)
         raise
 
+PAGE_SIZE_16KB = 16384
 ROOT = "src"
 GCLIENT_SPEC = """solutions = [
   {
@@ -52,18 +55,123 @@ def run_fetch(opts, logfile):
 
     source_dir = os.path.join(opts.dir, ROOT)
     run_command(['git', 'config', 'diff.ignoreSubmodules', 'dirty'], logfile, cwd=source_dir)
-    run_command(['./build/install-build-deps.sh'], logfile, cwd=source_dir)
+    # Pipe "y" to stdin because the script prompts for confirmation and stdout
+    # is redirected to the logfile, hiding the prompt in non-interactive environments.
+    run_command(['./build/install-build-deps.sh'], logfile, cwd=source_dir, stdin_input=b'y\n')
     run_command(['gclient', 'runhooks'], logfile, cwd=opts.dir)
+
+
+def check_16kb_alignment(aar_path, logfile):
+    """Check if 64-bit .so files in the AAR have 16KB-aligned LOAD segments.
+
+    Only enforces alignment on arm64-v8a and x86_64, since 32-bit architectures
+    (armeabi-v7a, x86) don't run on Android 16 16KB-kernel devices.
+
+    Returns True if all 64-bit .so files are 16KB-aligned, False otherwise.
+    """
+    if not os.path.exists(aar_path):
+        log(f'WARNING: Could not find {aar_path} to check alignment', logfile)
+        return False
+
+    # Only 64-bit architectures need 16KB alignment for Android 16
+    ARCHS_REQUIRING_16KB = {'arm64-v8a', 'x86_64'}
+
+    all_aligned = True
+
+    with zipfile.ZipFile(aar_path, 'r') as aar:
+        so_files = [f for f in aar.namelist() if f.endswith('.so')]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with zipfile.ZipFile(aar_path, 'r') as aar:
+            for so_file in so_files:
+                aar.extract(so_file, tmpdir)
+                so_path = os.path.join(tmpdir, so_file)
+
+                arch = so_file.split('/')[1] if '/' in so_file else ''
+                requires_16kb = arch in ARCHS_REQUIRING_16KB
+
+                # Use the architecture-specific readelf if available
+                readelf_cmd = 'readelf'
+                if 'arm64' in arch or 'aarch64' in arch:
+                    readelf_cmd = 'aarch64-linux-gnu-readelf'
+                elif 'armeabi' in arch:
+                    readelf_cmd = 'arm-linux-gnueabihf-readelf'
+
+                # Fall back to default readelf if the cross-arch one isn't available
+                try:
+                    result = subprocess.run(
+                        [readelf_cmd, '-l', so_path],
+                        capture_output=True, text=True, check=True
+                    )
+                except (FileNotFoundError, subprocess.CalledProcessError):
+                    try:
+                        result = subprocess.run(
+                            ['readelf', '-l', so_path],
+                            capture_output=True, text=True, check=True
+                        )
+                    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+                        log(f'WARNING: readelf failed for {so_file}, skipping alignment check: {e}', logfile)
+                        continue
+
+                # readelf -l output has each segment split across two lines:
+                #   LOAD  0x000... 0x000... 0x000...
+                #         0x000... 0x000... R E    0x4000
+                # The alignment is the last field on the continuation line.
+                in_load = False
+                so_aligned = True
+                for line in result.stdout.splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith('LOAD'):
+                        in_load = True
+                    elif in_load:
+                        parts = stripped.split()
+                        if parts:
+                            align_str = parts[-1]
+                            align = int(align_str, 16) if align_str.startswith('0x') else int(align_str)
+                            if align < PAGE_SIZE_16KB:
+                                if requires_16kb:
+                                    log(f'  FAIL: {so_file} LOAD segment alignment = {hex(align)} (need >= {hex(PAGE_SIZE_16KB)})', logfile)
+                                    all_aligned = False
+                                    so_aligned = False
+                                else:
+                                    log(f'  SKIP: {so_file} ({arch}) alignment = {hex(align)} - 32-bit, not required', logfile)
+                        in_load = False
+
+                if so_aligned and requires_16kb:
+                    log(f'  OK: {so_file} is 16KB aligned', logfile)
+
+    return all_aligned
 
 
 def run_build(opts, logfile):
     source_dir = os.path.join(opts.dir, ROOT)
     build_opts = []
+
+    gn_args = []
     if opts.official:
-        build_opts.append('--extra-gn-args=is_official_build=true')
+        gn_args.append('is_official_build=true chrome_pgo_phase=0')
+    if gn_args:
+        build_opts.append('--extra-gn-args=' + ' '.join(gn_args))
+
     if opts.unstripped:
         build_opts.append('--use-unstripped-libs')
     run_command(['./tools_webrtc/android/build_aar.py'] + build_opts, logfile, cwd=source_dir)
+
+    # Always check alignment after build
+    aar_path = os.path.join(source_dir, 'libwebrtc.aar')
+    log('\nChecking 16KB page alignment of built .so files...', logfile)
+    aligned = check_16kb_alignment(aar_path, logfile)
+
+    if aligned:
+        log('\n16KB alignment check PASSED - AAR is Android 16 compatible', logfile)
+    else:
+        raise RuntimeError(
+            '16KB alignment check FAILED for 64-bit .so files. '
+            'The WebRTC toolchain did not produce 16KB-aligned binaries. '
+            'You may need to patch build/config/compiler/BUILD.gn to add '
+            '"-Wl,-z,max-page-size=16384" to ldflags for Android targets.'
+        )
+
 
 def parse_args(argv):
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
github action succeeded 

https://github.com/ecobee/webrtc-android/actions/runs/22920918479


build.py:
- Add chrome_pgo_phase=0 to GN args to disable Profile-Guided Optimization (requires Chrome-specific profile data not available in standalone builds)
- Remove extra_ldflags GN arg (removed in newer milestones, corrupts gn desc JSON output when present)
- Add 16KB page alignment check for 64-bit .so files (arm64-v8a, x86_64) required for Android 16 compatibility. 32-bit archs are skipped.
- Fix readelf -l output parsing: LOAD segments span two lines, alignment value is the last field on the continuation line
- Pipe "y" to install-build-deps.sh stdin to prevent hang in non-interactive environments (Docker, CI) where stdout is redirected to logfile

build_webrtc.yml:
- Remove page_size_16kb and unstripped workflow inputs
- Simplify to branch_number and milestone inputs
- Build both stripped and unstripped AARs in a single workflow run
- Upload both AARs to the GitHub release (stripped for app distribution, unstripped for Crashlytics native symbol upload)
- Pin runner to ubuntu-22.04 for build compatibility
- Add Crashlytics symbol upload instructions in release notes

README.md:
- Add unstripped AAR build instructions (--unstripped flag)
- Add Crashlytics native symbol upload section with step-by-step commands
- Document 16KB page alignment check behavior
- Update GitHub Action documentation to reflect new dual-AAR workflow
- Update examples from milestone 119 to 145